### PR TITLE
Bump to ghc-7.10

### DIFF
--- a/src/Data/Label/Derive.hs
+++ b/src/Data/Label/Derive.hs
@@ -176,7 +176,7 @@ derive makeLabel signatures concrete tyname vars total ((field, _, fieldtyp), ct
     record rec fld val = val >>= \v -> recUpdE rec [return (fld, v)]
 
     -- Build a function declaration with both a type signature and body.
-    function (s, b) = liftM2 (,) 
+    function (s, b) = liftM2 (,)
         (sigD labelName s)
         (funD labelName [ clause [] (normalB b) [] ])
 
@@ -195,15 +195,11 @@ prettyTyVar (PlainTV  tv   ) = PlainTV (prettyName tv)
 prettyTyVar (KindedTV tv ki) = KindedTV (prettyName tv) ki
 
 prettyType :: Type -> Type
-prettyType (ForallT xs cx ty) = ForallT (map prettyTyVar xs) (map prettyPred cx) (prettyType ty)
+prettyType (ForallT xs cx ty) = ForallT (map prettyTyVar xs) (map prettyType cx) (prettyType ty)
 prettyType (VarT nm         ) = VarT (prettyName nm)
 prettyType (AppT ty tx      ) = AppT (prettyType ty) (prettyType tx)
 prettyType (SigT ty ki      ) = SigT (prettyType ty) ki
 prettyType ty                 = ty
-
-prettyPred :: Pred -> Pred
-prettyPred (ClassP nm tys) = ClassP (prettyName nm) (map prettyType tys)
-prettyPred (EqualP ty tx ) = EqualP (prettyType ty) (prettyType tx)
 
 -- IsString instances for TH types.
 

--- a/src/Network/Protocol/Cookie.hs
+++ b/src/Network/Protocol/Cookie.hs
@@ -104,7 +104,7 @@ $(mkLabels [''Cookie])
 
 -- | Short notation for cookies
 
-data CookieShort = 
+data CookieShort =
   CookieShort
     { _s_name  :: String
     , _s_value   :: String
@@ -158,10 +158,10 @@ showSetCookie c =
 infixr 0 !$
 
 parseSetCookie :: String -> Cookie
-parseSetCookie s = 
+parseSetCookie s =
   let p = fw (keyValues ";" "=") s
   in Cookie
-    { _name       = p !$ headMay >>> fmap fst >>> fromMaybe "" 
+    { _name       = p !$ headMay >>> fmap fst >>> fromMaybe ""
     , _value      = p !$ headMay >>> fmap snd >>> fromMaybe ""
     , _comment    = p !$ lookup "comment"
     , _commentURL = p !$ lookup "commentURL"

--- a/src/Network/Protocol/Http/Data.hs
+++ b/src/Network/Protocol/Http/Data.hs
@@ -27,7 +27,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 -}
-{-# LANGUAGE TemplateHaskell, TypeOperators #-}
+{-# LANGUAGE TemplateHaskell, TypeOperators, KindSignatures #-}
 module Network.Protocol.Http.Data where
 
 import Control.Category

--- a/src/Test/Debug.hs
+++ b/src/Test/Debug.hs
@@ -1,6 +1,5 @@
 -- FIXME: in order debug to work
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 
@@ -12,9 +11,9 @@ import Control.Monad.Trans
 class Debug x where
     debug :: (MonadIO m) => x -> m ()
 
-instance (Show x) => Debug x where
+instance {-# OVERLAPPABLE #-} (Show x) => Debug x where
     debug = liftIO . putStrLn . show . show
 
-instance Debug String where
+instance {-# OVERLAPPING #-} Debug String where
     debug = liftIO . putStrLn . show
 

--- a/src/VKQ.hs
+++ b/src/VKQ.hs
@@ -195,10 +195,10 @@ cmd (Options v (Music (MO act _ q@(_:_) fmt _ _ _ _))) = do
     printf "%s\n" (mr_format fmt m)
   printf "total %d\n" len
 
--- List audio files 
+-- List audio files
 cmd (Options v (Music (MO act True [] fmt _ _ _ _))) = do
   let e = (envcall act) { verbose = v }
-  (Response ms) <- api_ e "audio.get" []
+  Response (ms :: [MusicRecord]) <- api_ e "audio.get" []
   forM_ ms $ \m -> do
     printf "%s\n" (mr_format fmt m)
 cmd (Options _ (Music (MO _ False [] _ _ _ [] _))) = do
@@ -207,7 +207,7 @@ cmd (Options _ (Music (MO _ False [] _ _ _ [] _))) = do
 -- Download audio files
 cmd (Options v (Music (MO act False [] _ ofmt odir rid sk))) = do
   let e = (envcall act) { verbose = v }
-  Response ms <- api_ e "audio.getById" [("audios", concat $ intersperse "," rid)]
+  Response (ms :: [MusicRecord]) <- api_ e "audio.getById" [("audios", concat $ intersperse "," rid)]
   forM_ ms $ \m -> do
     (fp, mh) <- openFileMR odir sk ofmt m
     case mh of
@@ -252,7 +252,7 @@ openFileMR dir sk fmt m = do
   let (_,ext) = splitExtension (url m)
   let name = mr_format fmt m
   let name' = replaceExtension name (takeWhile (/='?') ext)
-  let fp =  (dir </> name') 
+  let fp =  (dir </> name')
   e <- doesFileExist fp
   case (e && sk) of
     True -> do

--- a/src/Web/VKHS/API/Aeson.hs
+++ b/src/Web/VKHS/API/Aeson.hs
@@ -48,7 +48,7 @@ instance FromJSON MusicRecord where
   parseJSON = parseGeneric
 
 instance FromJSON WallRecord where
-  parseJSON (Object o) = 
+  parseJSON (Object o) =
     WR <$> (o .: "id")
        <*> (o .: "to_id")
        <*> (o .: "from_id")
@@ -56,7 +56,7 @@ instance FromJSON WallRecord where
        <*> (o .: "date")
   parseJSON o = parseJSON_obj_error "WallRecord" o
 
-instance (FromJSON a) => FromJSON (SizedList [a]) where
+instance (FromJSON a) => FromJSON (SizedList a) where
   parseJSON (A.Array v) = do
     n <- A.parseJSON (V.head v)
     t <- A.parseJSON (A.Array (V.tail v))

--- a/src/Web/VKHS/API/Types.hs
+++ b/src/Web/VKHS/API/Types.hs
@@ -7,10 +7,10 @@ import Data.Data
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
-data Response a = Response a
-  deriving(Show)
+newtype Response a = Response a
+  deriving (Show)
 
-data SizedList a = SL Int a
+data SizedList a = SL Int [a]
 
 data MusicRecord = MR
   { aid :: Int
@@ -32,7 +32,7 @@ data UserRecord = UR
   , faculty :: Maybe Int
   , faculty_name :: Maybe String
   , graduation :: Maybe Int
-  } deriving(Show,Data,Typeable)
+  } deriving (Show, Data, Typeable)
 
 data WallRecord = WR
   { wid :: Int
@@ -40,15 +40,13 @@ data WallRecord = WR
   , from_id :: Int
   , wtext :: String
   , wdate :: Int
-  } deriving(Show)
+  } deriving (Show)
 
 publishedAt :: WallRecord -> UTCTime
 publishedAt wr = posixSecondsToUTCTime $ fromIntegral $ wdate wr
 
-
 data RespError = ER
   { error_code :: Int
   , error_msg :: String
-  } deriving(Show)
-
+  } deriving (Show)
 


### PR DESCRIPTION
The short list of breaking changes to ghc and libraries involved here:
- Pred, ClassP, EqualP are completely deprecated in new TH
- OverlappingInstances extension is thrown away in favor of per-instance pragmas
- forM_ is generalized to Foldable

Tagsoup-parsec is broken too, but there is already a bumping pull request: https://github.com/ozataman/tagsoup-parsec/pull/1. As there is no version limit on tagsoup-parsec in vkhs cabal file, it will automatically get fixed version after merge. As for now, one can just install that fixed branch manually.
