### PR TITLE
add: oAUTH for web sites

### DIFF
--- a/VKHS.cabal
+++ b/VKHS.cabal
@@ -20,20 +20,9 @@ source-repository head
     type:     git
     location: https://github.com/grwlf/vkhs.git
 
-executable vknews
-  extra-libraries: curl
-  hs-source-dirs:    src
-  main-is:           VKNews.hs
-  build-tools:     hsc2hs
-  ghc-options:     -Wall -fwarn-tabs
-
-executable vkq
-  hs-source-dirs:    src
-  main-is:           VKQ.hs
-
 library
   hs-source-dirs:    src
-  other-modules:     Test.Debug, Test.Data, Test.API, Network.Shpider.Forms,
+  other-modules:     Network.Shpider.Forms,
     Network.Protocol.Uri, Network.Protocol.Mime, Network.Protocol.Http,
     Network.Protocol.Cookie, Network.Protocol.Uri.Remap,
     Network.Protocol.Uri.Query, Network.Protocol.Uri.Printer,
@@ -74,6 +63,7 @@ library
                      tagsoup,
                      failure,
                      curlhs,
+                     http-conduit,
                      safe,
                      parsec,
                      split,

--- a/src/Web/VKHS/Types.hs
+++ b/src/Web/VKHS/Types.hs
@@ -51,7 +51,7 @@ allAccess =
   , Notifications
   , Stats
   -- , Ads
-  -- , Offline
+  , Offline
   ]
 
 -- See API docs http://vk.com/developers.php?oid=-1&p=Права_доступа_приложений (in
@@ -61,7 +61,8 @@ allAccess =
 data Verbosity = Normal | Trace | Debug
   deriving(Enum,Eq,Ord,Show)
 
-type ClientId = String
+type ClientId     = String
+type ClientSecret = String
 
 data LoginEnv = LoginEnv
   { formdata :: [(String,String)]
@@ -70,6 +71,8 @@ data LoginEnv = LoginEnv
   -- ^ Access rights, required by later API calls
   , clientId :: ClientId
   -- ^ Application ID provided by vk.com
+  , clientSecret :: ClientSecret
+  -- ^ Application secret code provided by vk.com
   } deriving(Show)
 
 data CallEnv = CallEnv


### PR DESCRIPTION
Can be used like (lots of service lines are omitted)

``` haskell
  let loginVk = VK.env "1111111" "asdasdasdasdasdasda" "" "" [VK.Photos, VK.Offline]
       returnUrlVK = "http://local.host:3000/vk"
  vkurl <- VK.getUserAccessTokenStep1 loginVk returnUrlVK
  scotty 3000 $ do -- Using some server like Scotty to handle response
    get "/vk" $ do
      code <- param "code"
      token <- liftIO $ VK.getUserAccessTokenStep2 loginVk returnUrlVK code
      ans <- liftIO $ case token of
        Right (at, _, _) -> VK.api (VK.mkEnv $ VK.CallEnv at) "users.get" [
            ("uids", "1")
            , ("fields","first_name,last_name,nickname,screen_name")
            , ("name_case","nom")
            ]
        Left a -> undefined
      html $ LT.fromStrict $ T.pack $ show ans
```

Do you like the idea? If you agree I will update this PR to a better one.
