### PR TITLE
"Artist" and "Title" tags now come from metadata.

### DIFF
--- a/VKHS.cabal
+++ b/VKHS.cabal
@@ -61,8 +61,8 @@ library
                      EitherT,
                      vector,
                      filepath,
-                     directory
-
+                     directory,
+                     taglib
 
 executable vkq
   hs-source-dirs:    app/vkq, app/common, src
@@ -71,5 +71,3 @@ executable vkq
                      Util
   build-depends:     regexpr,
                      text
-
-


### PR DESCRIPTION
[-] removed EitherT dependency (put Control.Monad.ExceptT instead)
[+] made music downloader override "Artist" and "Title" tags with values from metadata;
    it also cleans all other tags accessible by "taglib" package.
