### PR TITLE
Add `process` to dependency to fix failing build

### DIFF
--- a/VKHS.cabal
+++ b/VKHS.cabal
@@ -49,6 +49,7 @@ library
                      network-uri,
                      pipes,
                      pipes-http,
+                     process,
                      time,
                      data-default-class,
                      parsec,


### PR DESCRIPTION
Without library `process` in list of build-depends, `stack build` with
resolver lts-9.0 was failing to build project with the following error:

```
src/Web/VKHS.hs:31:1: error:
    Failed to load interface for ‘System.Process’
    It is a member of the hidden package ‘process-1.4.3.0’.
    Perhaps you need to add ‘process’ to the build-depends in your .cabal file.
```