### PR TITLE
Add a Semigroup instance for Sized

### DIFF
--- a/src/Web/VKHS/API/Types.hs
+++ b/src/Web/VKHS/API/Types.hs
@@ -140,9 +140,12 @@ instance FromJSON a => FromJSON (Sized a) where
   parseJSON = Aeson.withObject "Result" (\o ->
     Sized <$> o .: "count" <*> o .: "items")
 
+instance Semigroup a => Semigroup (Sized a) where
+  (Sized x a) <> (Sized y b) = Sized (x+y) (a<>b)
+
 instance Monoid a => Monoid (Sized a) where
   mempty = Sized 0 mempty
-  mappend (Sized x a) (Sized y b) = Sized (x+y) (a<>b)
+  mappend = (<>)
 
 data Deact = Banned | Deleted | OtherDeact Text
   deriving(Show,Eq,Ord,Data,Typeable)


### PR DESCRIPTION
This PR adds a Semigroup instance for Sized before making in an instance of Monoid. This is required in order to build VKHS with `base-4.11.1.0` contained in Stack's `lts-12.25` snapshot. This version of base forbids declaring a type as Monoid without making it a Semigroup [1]:

```hs
class Semigroup a => Monoid a where
```
[1]: <https://www.stackage.org/haddock/lts-12.25/base-4.11.1.0/Data-Monoid.html#t:Monoid>.

I hope this doesn't break builds with other versions of base, but I'm not sure. @grwlf, please check if this works with tools you use for building VKHS, and if so, merge the PR.